### PR TITLE
Add kickbox gem for verifying email when user registers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'figaro'
 gem 'httparty'
 gem 'fast_jsonapi'
 gem 'bootsnap', '>= 1.1.0', require: false
-
+gem 'kickbox'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors', require: 'rack/cors'
 
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'figaro'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     diff-lcs (1.3)
     docile (1.3.1)
     erubi (1.8.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
     ffi (1.10.0)
@@ -67,6 +69,9 @@ GEM
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
+    kickbox (2.0.3)
+      faraday (~> 0.9)
+      json (>= 1.8)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -88,6 +93,7 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.6)
     multi_xml (0.6.0)
+    multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -184,6 +190,7 @@ DEPENDENCIES
   fast_jsonapi
   figaro
   httparty
+  kickbox
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,10 @@
+require "kickbox"
 class Api::V1::UsersController<ApplicationController
 
   def create
-    if current_user
+    if verify_email.body["result"] == "undeliverable"
+      render :json => {:error => "This does not appear to be a valid email"}.to_json, :status => 401
+    elsif current_user
       render :json => {:error => "There is already an account created with this email address. Check your password, or register with a different email address to log in."}.to_json, :status => 401
     else
       user = User.create(user_params) if matching_passwords?
@@ -27,4 +30,9 @@ class Api::V1::UsersController<ApplicationController
     params[:password] == params[:password_confirmation]
   end
 
+  def verify_email
+    client   = Kickbox::Client.new(ENV['KICKBOX_API'])
+    kickbox  = client.kickbox()
+    response = kickbox.verify(user_params[:email])
+  end
 end


### PR DESCRIPTION
What does this PR do? 
This PR installs the kickbox gem so that a user can be notified if their email is invalid and not an active email account. 

Where should the reviewer start?
Reviewer can check in the users controller. Right now, this functionality is all in the controller. We may want to abstract this to the model later? 